### PR TITLE
Add a patch to make calls to Graphviz binaries work on Windows

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - shell.patch  # [win]
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
@@ -31,6 +31,8 @@ requirements:
 test:
   imports:
     - graphviz
+  requires:
+    - dask
 
 about:
   home: http://github.com/xflr6/graphviz

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,9 +9,14 @@ source:
   fn: python-graphviz-{{ version }}.zip
   url: https://pypi.io/packages/source/g/graphviz/graphviz-{{ version }}.zip
   sha256: {{ sha256 }}
+  patches:
+    # This is needed because Graphviz binaries (e.g. dot) are redefined as
+    # batch scripts in the Graphviz conda-forge package. Hence, it doesn't
+    # make sense to submit this patch upstream
+    - shell.patch
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "0.5.1" %}
-{% set sha256 = "d8f8f369a5c109d3fc971bbc1860b6848515d210aee8f5019c460351dbb00a50" %}
+{% set version = "0.5.2" %}
+{% set sha256 = "60ea67b383e3feb71fd0cb3137c02f8c4a76935996cf06a9e77d6150a90d034a" %}
 
 package:
   name: python-graphviz
@@ -13,10 +13,10 @@ source:
     # This is needed because Graphviz binaries (e.g. dot) are redefined as
     # batch scripts in the Graphviz conda-forge package. Hence, it doesn't
     # make sense to submit this patch upstream
-    - shell.patch
+    - shell.patch  # [win]
 
 build:
-  number: 1
+  number: 0
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,3 +50,4 @@ about:
 extra:
   recipe-maintainers:
     - jakirkham
+    - ccordoba12

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+
+# Dask test
+
+import dask.array as da
+
+x = da.ones(4, chunks=(2,))
+for fmt in ['pdf', 'png', 'dot', 'svg']:
+    (x + 1).sum().visualize(filename='graph.%s' % fmt)

--- a/recipe/shell.patch
+++ b/recipe/shell.patch
@@ -1,0 +1,12 @@
+--- graphviz/backend.py.old	Sun Feb 12 23:11:38 2017
++++ graphviz/backend.py	Sun Feb 12 23:12:46 2017
+@@ -120,7 +120,8 @@
+ 
+     try:
+         proc = subprocess.Popen(args, stdin=subprocess.PIPE,
+-            stdout=subprocess.PIPE, startupinfo=STARTUPINFO)
++            stdout=subprocess.PIPE, startupinfo=STARTUPINFO,
++            shell=(os.name == 'nt'))
+     except OSError as e:
+         if e.errno == errno.ENOENT:
+             raise RuntimeError('failed to execute %r, '


### PR DESCRIPTION
This is needed because Graphviz binaries (e.g. `dot`) are redefined as batch scripts in the Graphviz conda-forge package. Hence, it doesn't make sense to submit this patch upstream.